### PR TITLE
Remove instances of txtExpr and txtStmt

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -61,7 +61,7 @@ $(ABLEC_JAR): $(GRAMMAR_SOURCES)
 	silver -o $@ $(SVFLAGS) $(ARTIFACT)
 
 %.c: %.xc $(ABLEC_JAR)
-	java -jar $(ABLEC_JAR) $< $(XCFLAGS)
+	java -Xss6M -jar $(ABLEC_JAR) $< $(XCFLAGS)
 
 %.out: %.o $(SRC_SOURCES) | libs
 	$(CC) $(LDFLAGS) $< $(LOADLIBES) $(LDLIBS) -o $@

--- a/examples/sample_project/Makefile
+++ b/examples/sample_project/Makefile
@@ -2,13 +2,13 @@ a.out:	exprs_main.o exprs.o
 	gcc exprs_main.o exprs.o
 
 exprs.c:	exprs.xc exprs.h ../ableC.jar
-	java -jar ../ableC.jar exprs.xc
+	java -Xss6M -jar ../ableC.jar exprs.xc
 
 exprs.o:	exprs.c
 	gcc -c exprs.c -o exprs.o
 
 exprs_main.c:	exprs_main.xc  exprs.h ../ableC.jar
-	java -jar ../ableC.jar exprs_main.xc
+	java -Xss6M -jar ../ableC.jar exprs_main.xc
 
 exprs_main.o:	exprs_main.c
 	gcc -c exprs_main.c -o exprs_main.o

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/AbstractSyntax.sv
@@ -6,4 +6,5 @@ imports silver:langutil:pp with implode as ppImplode ;
 imports edu:umn:cs:melt:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction:parsing;
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
@@ -328,7 +328,7 @@ top::Constructor ::= n::String tms::TypeNames
   forwards to
     allocConstructor(
       n, tms,
-      \ty::String -> txtExpr("(" ++ ty ++ " *) malloc (sizeof(" ++ ty ++ "))", location=builtIn()),
+      \ty::String -> txtExpr(s"""(${ty}*) malloc (sizeof(${ty}))""", location=top.location),
       location=top.location);
 }
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
@@ -328,16 +328,15 @@ top::Constructor ::= n::String tms::TypeNames
   forwards to
     allocConstructor(
       n, tms,
-      \ty::String -> parseStmt(s"""
-        proto_typedef ${ty};
-        temp = (${ty}*) malloc (sizeof(${ty}));
-        """),
+      \ty::String -> parseExpr(s"""
+        ({proto_typedef ${ty};
+          (${ty}*) malloc (sizeof(${ty}));})"""),
       location=top.location);
 }
 
 -- Takes a function that takes a String and returns an Expr that does the allocation for that type
 abstract production allocConstructor
-top::Constructor ::= n::String tms::TypeNames allocStmt::(Stmt ::= String)
+top::Constructor ::= n::String tms::TypeNames allocExpr::(Expr ::= String)
 {
   production attribute initStmts::[Stmt] with ++;
   initStmts := [];
@@ -405,7 +404,7 @@ top::Constructor ::= n::String tms::TypeNames allocStmt::(Stmt ::= String)
                   nothingInitializer()),
                 nilDeclarator()))),
 
-          allocStmt(top.topTypeName),
+          mkAssign("temp", allocExpr(top.topTypeName), builtIn()),
           
           exprStmt(
             binaryOpExpr(

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/datatype/abstractsyntax/DataType.sv
@@ -328,13 +328,16 @@ top::Constructor ::= n::String tms::TypeNames
   forwards to
     allocConstructor(
       n, tms,
-      \ty::String -> txtExpr(s"""(${ty}*) malloc (sizeof(${ty}))""", location=top.location),
+      \ty::String -> parseStmt(s"""
+        proto_typedef ${ty};
+        temp = (${ty}*) malloc (sizeof(${ty}));
+        """),
       location=top.location);
 }
 
 -- Takes a function that takes a String and returns an Expr that does the allocation for that type
 abstract production allocConstructor
-top::Constructor ::= n::String tms::TypeNames allocExpr::(Expr ::= String)
+top::Constructor ::= n::String tms::TypeNames allocStmt::(Stmt ::= String)
 {
   production attribute initStmts::[Stmt] with ++;
   initStmts := [];
@@ -402,8 +405,7 @@ top::Constructor ::= n::String tms::TypeNames allocExpr::(Expr ::= String)
                   nothingInitializer()),
                 nilDeclarator()))),
 
-
-          mkAssign("temp", allocExpr(top.topTypeName), builtIn()),
+          allocStmt(top.topTypeName),
           
           exprStmt(
             binaryOpExpr(

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/ADTPatterns.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/ADTPatterns.sv
@@ -98,17 +98,16 @@ p::Pattern ::= id::String ps::PatternList
   -- ps.transformIn = nullStmt();
 
   p.transform = foldStmt ( [
-      txtStmt( "/* matching against a ADT constructor pattern */" ),
-      txtStmt( "/* match against constructor */" ),
+      exprStmt(comment("matching against a ADT constructor pattern" , location=p.location)),
+      exprStmt(comment("match against constructor", location=p.location)),
       ifStmt(
-        txtExpr( " (* _curr_scrutinee_ptr)->tag != " ++ tag_name ++ " ", 
-                 location = p.location ),
+        parseExpr( " (* _curr_scrutinee_ptr)->tag != " ++ tag_name ++ " "),
         -- then
-        txtStmt( "_match = 0;" ),
+        parseStmt( "_match = 0;" ),
         -- else
         foldStmt( [
-          txtStmt( "/* match against sub-patterns," ++
-                   " setting _match to 0 on a fail */" ) ,
+          exprStmt(comment("match against sub-patterns," ++
+                   " setting _match to 0 on a fail", location=p.location)),
 
  
           declStmt(
@@ -116,8 +115,7 @@ p::Pattern ::= id::String ps::PatternList
              consDeclarator(
                declarator( name("_cons_scrutinee_ptr", location=p.location), 
                  pointerTypeExpr (nilQualifier(), baseTypeExpr()), nilAttribute(), 
-                 justInitializer( exprInitializer( txtExpr( "_curr_scrutinee_ptr",
-                                                            location=p.location ) ) ) ),
+                 justInitializer( exprInitializer( parseExpr( "_curr_scrutinee_ptr") ) ) ),
                nilDeclarator() ) ) ),
 
 
@@ -157,10 +155,10 @@ Stmt ::= pt::Stmt ptype::Type tag::String pos::Integer l::Location
              name("_curr_scrutinee_ptr", location=fakeloc),
              pointerTypeExpr (nilQualifier(), baseTypeExpr()), nilAttribute(), 
              justInitializer( exprInitializer( 
-               txtExpr( "& (* _cons_scrutinee_ptr)->contents." ++ tag ++ ".f" ++ 
-                        toString(pos),
+               parseExpr( "& (* _cons_scrutinee_ptr)->contents." ++ tag ++ ".f" ++ 
+                        toString(pos)
 --                        location=l
-                        location=fakeloc
+                        
                 ) ) ) ),
            nilDeclarator() ) ) ),
 
@@ -171,7 +169,7 @@ Stmt ::= pt::Stmt ptype::Type tag::String pos::Integer l::Location
 
 
 {-
-    [ txtStmt ("FIX 
+    [ parseStmt ("FIX 
 
 Expr * * _curr_scrutinee_ptr = & (* _curr_scrutinee_ptr)->contents.Add.f0;") ;
 
@@ -200,7 +198,7 @@ Boolean ::= n::String cnst::Pair<String [Type]>
   p.transform =
    foldStmt (
      (if   p.depth > 0 
-      then [txtStmt("_current_ADT" ++ "[" ++ toString(p.depth) ++ "] = " ++
+      then [parseStmt("_current_ADT" ++ "[" ++ toString(p.depth) ++ "] = " ++
                     "( void *)" ++
                     "((" ++ p.parent_idType ++ ")" ++
                     "_current_ADT" ++ "[" ++ 
@@ -211,7 +209,7 @@ Boolean ::= n::String cnst::Pair<String [Type]>
 
     [ ifStmt(
         -- check that the 'tag' field of the current node has the tag for this pattern.
-        txtExpr(" ((" ++ idType ++ ")" ++ 
+        parseExpr(" ((" ++ idType ++ ")" ++ 
                 "_current_ADT" ++ "[" ++ toString(p.depth) ++ "])->tag == " ++
                 " " ++ idTypeIndicator ++ "_" ++ id, location=p.location),
       

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/AbstractSyntax.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/AbstractSyntax.sv
@@ -6,5 +6,6 @@ imports silver:langutil:pp with implode as ppImplode;
 imports edu:umn:cs:melt:ableC:abstractsyntax;
 imports edu:umn:cs:melt:ableC:abstractsyntax:construction;
 imports edu:umn:cs:melt:ableC:abstractsyntax:env;
+imports edu:umn:cs:melt:ableC:abstractsyntax:construction:parsing;
 
 imports edu:umn:cs:melt:exts:ableC:algebraicDataTypes:datatype:abstractsyntax;

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/ExprClauses.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/ExprClauses.sv
@@ -74,7 +74,7 @@ cs::ExprClauses ::= c::ExprClause
   cs.errors := c.errors;
 
   cs.transform = c.transform;
-  c.transformIn = txtStmt("printf(\"Failed to match any patterns in match expression.\\n\"); exit(1);\n");
+  c.transformIn = parseStmt("printf(\"Failed to match any patterns in match expression.\\n\"); exit(1);\n");
   cs.typerep = c.typerep;
 }
 
@@ -94,9 +94,9 @@ c::ExprClause ::= p::Pattern e::Expr
 
   c.transform
     = foldStmt( [
-        txtStmt( "/* matching for pattern " ++ show(80,p.pp) ++ " */"),
+        exprStmt(comment("matching for pattern " ++ show(80,p.pp), location=c.location)),
 
-        txtStmt( "/* ... declarations of pattern variables */"),
+        exprStmt(comment("... declarations of pattern variables", location=c.location)),
 	foldStmt( p.decls ),
 
         mkDecl ("_curr_scrutinee_ptr", pointerType( nilQualifier(), c.expectedType), 

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/MatchExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/MatchExpr.sv
@@ -12,7 +12,7 @@ e::Expr ::= scrutinee::Expr  clauses::ExprClauses
   local fwrd::Expr =
     stmtExpr (
       foldStmt( [
-        txtStmt ("/* match (" ++ show(100,scrutinee.pp) ++ ") ... */"),
+        exprStmt(comment("match (" ++ show(100,scrutinee.pp) ++ ") ...", location=e.location)),
 
         declStmt(
           variableDecls( [], nilAttribute(), directTypeExpr(clauses.typerep),

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/MatchStmt.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/MatchStmt.sv
@@ -19,7 +19,7 @@ e::Stmt ::= scrutinee::Expr  clauses::StmtClauses
     then warnStmt(lerrors)
     else
       compoundStmt(foldStmt( [
-        txtStmt ("/* match (" ++ show(100,scrutinee.pp) ++ ") ... */"),
+        exprStmt(comment("match (" ++ show(100,scrutinee.pp) ++ ") ...", location=scrutinee.location)),
 
         mkDecl( "_match_scrutinee_val", scrutinee.typerep, scrutinee, 
                 scrutinee.location),

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/Pattern.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/Pattern.sv
@@ -70,7 +70,7 @@ p::Pattern ::= id::String
         declRefExpr (name("_curr_scrutinee_ptr",location=p.location), location=p.location),
 	p.location),
       p.location);
-    -- txtStmt(id ++ " = * _curr_scrutinee_ptr;") ;
+    -- parseStmt(id ++ " = * _curr_scrutinee_ptr;") ;
 }
 
 abstract production patternWildcard
@@ -94,10 +94,9 @@ p::Pattern ::= constExpr::Expr
 
   p.transform 
     = ifStmt(
-        txtExpr("( *_curr_scrutinee_ptr != " ++ show(10, constExpr.pp) ++ ")",
-                location=p.location),
+        parseExpr("( *_curr_scrutinee_ptr != " ++ show(10, constExpr.pp) ++ ")"),
         -- then clause
-        txtStmt("_match = 0;"),
+        parseStmt("_match = 0;"),
         -- else clause
         nullStmt()
       );
@@ -123,10 +122,9 @@ p::Pattern ::= s::String
 
   p.transform =
     ifStmt(
-      txtExpr("strcmp( *_curr_scrutinee_ptr,(" ++ s ++ "))",
-              location=p.location),
+      parseExpr("strcmp( *_curr_scrutinee_ptr,(" ++ s ++ "))"),
         -- then clause
-        txtStmt("_match = 0;"),
+        parseStmt("_match = 0;"),
         -- else clause
         nullStmt()
       );

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/PatternNotBoth.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/PatternNotBoth.sv
@@ -41,7 +41,7 @@ p::Pattern ::= p1::Pattern
 
   p.transform = seqStmt (p1.transform, flip_match);
   local flip_match :: Stmt = 
-    txtStmt ("if (_match == 0) { _match = 1; } else { _match = 0; }");
+    parseStmt ("if (_match == 0) { _match = 1; } else { _match = 0; }");
 }
 
 
@@ -53,5 +53,5 @@ p::Pattern ::= e::Expr
   p.decls = [];
   p.defs := [];
   p.errors := e.errors;
-  p.transform = ifStmt(e, nullStmt(), txtStmt("_match = 0;") );
+  p.transform = ifStmt(e, nullStmt(), parseStmt("_match = 0;") );
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/StmtClauses.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/abstractsyntax/StmtClauses.sv
@@ -56,7 +56,7 @@ cs::StmtClauses ::=
   cs.pp = text("");
   cs.errors := [];
 
-  cs.transform = txtStmt("/* no match, do nothing. */");
+  cs.transform = exprStmt(comment("no match, do nothing.", location=cs.location));
 }
   
 
@@ -96,8 +96,8 @@ c::StmtClause ::= p::Pattern s::Stmt
 
   c.transform = 
     foldStmt( [
-        txtStmt( "/* matching for pattern " ++ show(80,p.pp) ++ " */"),
-        txtStmt( "/* ... declarations of pattern variables */"),
+        exprStmt(comment("matching for pattern " ++ show(80,p.pp), location=c.location)),
+        exprStmt(comment("... declarations of pattern variables", location=c.location)),
         
         foldStmt( p.decls ),
 

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/concretesyntax/MatchExpr.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/concretesyntax/MatchExpr.sv
@@ -18,7 +18,7 @@ m::Match ::= '(' scrutinee::Expr_c ')' '(' cs::ExprClauses ')'
   m.ast = abs:matchExpr( scrutinee.ast, cs.ast, location=m.location );
 --  cs.defaultClauseAST = 
 --    abs:defaultClause(
---      stmtExpr( txtStmt("printf(\"BOOM!\\n\"); exit(1);"), scrutinee.ast, location=m.location), 
+--      stmtExpr( parseStmt("printf(\"BOOM!\\n\"); exit(1);"), scrutinee.ast, location=m.location), 
 --      location=m.location
 --     );
 }

--- a/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/concretesyntax/MatchStmt.sv
+++ b/grammars/edu.umn.cs.melt.exts.ableC.algebraicDataTypes/patternmatching/concretesyntax/MatchStmt.sv
@@ -34,7 +34,7 @@ m::MatchStmt ::= '(' scrutinee::Expr_c ')' '{' cs::StmtClauses '}'
 
 --  cs.defaultClauseAST = 
 --    abs:defaultClause(
---      stmtExpr( txtStmt("printf(\"BOOM!\\n\"); exit(1);"), scrutinee.ast, location=m.location), 
+--      stmtExpr( parseStmt("printf(\"BOOM!\\n\"); exit(1);"), scrutinee.ast, location=m.location), 
 --      location=m.location
 --     );
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -62,14 +62,14 @@ $(ABLEC_JAR): $(GRAMMAR_SOURCES)
 	silver -o $(ABLEC_JAR) $(SVFLAGS) $(ARTIFACT)
 
 %.c: %.xc $(ABLEC_JAR)
-	java -jar $(ABLEC_JAR) $< $(XCFLAGS)
+	java -Xss6M -jar $(ABLEC_JAR) $< $(XCFLAGS)
 
 %.out: %.o $(SRC_SOURCES) | libs
 	$(CC) $(LDFLAGS) $< $(LOADLIBES) $(LDLIBS) -o $@
 
 translate_error/%.test: translate_error/%.xc $(ABLEC_JAR)
-	@echo "java -jar $(ABLEC_JAR) $< $(XCFLAGS)"
-	@if java -jar $(ABLEC_JAR) $< $(XCFLAGS); then echo "Failed to error"; exit 1; fi
+	@echo "java -Xss6M -jar $(ABLEC_JAR) $< $(XCFLAGS)"
+	@if java -Xss6M -jar $(ABLEC_JAR) $< $(XCFLAGS); then echo "Failed to error"; exit 1; fi
 	touch $@
 
 runtime_error/%.test: runtime_error/%.out


### PR DESCRIPTION
This replaces all instances of `txtExpr` and `txtStmt` with either `comment`, `parseExpr`, or `parseStmt`.

There's only one piece of functionality that changed as a result of this-- the malloc helper passed into allocConstructor was changed so it could include a `proto_typedef` line. 

We discussed using `comment` in our meeting on Monday to replace the operations that were already just producing comments, which avoids having to do more such work-arounds, but I'm not sure if there's some reason we shouldn't be using it (the comment on it in ableC sort-of implies that).